### PR TITLE
feat: show progress as n/total format instead of percentage

### DIFF
--- a/src/plugins/local-llm-rename/visit-all-identifiers.ts
+++ b/src/plugins/local-llm-rename/visit-all-identifiers.ts
@@ -54,9 +54,9 @@ export async function visitAllIdentifiers(
     }
     markVisited(smallestScope, smallestScopeNode.name, visited);
 
-    onProgress?.(visited.size / numRenamesExpected);
+    onProgress?.(visited.size / numRenamesExpected, visited.size, numRenamesExpected);
   }
-  onProgress?.(1);
+  onProgress?.(1, numRenamesExpected, numRenamesExpected);
 
   const stringified = await transformFromAstAsync(ast);
   if (stringified?.code == null) {

--- a/src/progress.ts
+++ b/src/progress.ts
@@ -22,14 +22,22 @@ function formatBytes(numBytes: number) {
   return `${numBytes.toFixed(2)} ${units[unitIndex]}`;
 }
 
-export function showPercentage(percentage: number) {
+export function showPercentage(percentage: number, current?: number, total?: number) {
   const percentageStr = Math.round(percentage * 100);
+  let progressText: string;
+  
+  if (current !== undefined && total !== undefined) {
+    progressText = `Processing: ${current}/${total}`;
+  } else {
+    progressText = `Processing: ${percentageStr}%`;
+  }
+  
   if (!verbose.enabled) {
     process.stdout.clearLine?.(0);
     process.stdout.cursorTo(0);
-    process.stdout.write(`Processing: ${percentageStr}%`);
+    process.stdout.write(progressText);
   } else {
-    verbose.log(`Processing: ${percentageStr}%`);
+    verbose.log(progressText);
   }
   if (percentage === 1) {
     process.stdout.write("\n");


### PR DESCRIPTION
## Summary
- Changed progress display from percentage to n/total format (e.g., "Processing: 1/28")
- Provides clearer visibility of remaining work during processing

## Changes
- Modified `showPercentage()` function to accept optional `current` and `total` parameters
- Updated `visitAllIdentifiers()` to pass current and total values when calling progress callback
- Progress now displays as "Processing: n/nnnnn" format for better user experience

## Test plan
- [x] Built the project successfully with `npm run build`
- [x] Tested with sample JavaScript file to verify progress display
- [x] Confirmed progress shows as "Processing: 1/28", "Processing: 2/28", etc.
- [x] Verified both verbose and non-verbose modes work correctly