### PR TITLE
체크포인트 기능 추가: 중단된 작업 재시작 지원

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,24 @@ humanify openai --apiKey="your-token" obfuscated-file.js
 Alternatively you can also use an environment variable `OPENAI_API_KEY`. Use
 `humanify --help` to see all available options.
 
+#### Checkpoint Feature (Resume on Failure)
+
+The OpenAI mode now supports checkpointing to resume processing if the request is interrupted:
+
+```shell
+# Enable checkpoint saving
+humanify openai --checkpoint obfuscated-file.js
+
+# Resume from last checkpoint
+humanify openai --resume obfuscated-file.js
+```
+
+When checkpoint is enabled:
+- Progress is saved every 5 renamed identifiers
+- If the process is interrupted, you can resume from where it left off
+- Partial results are saved and merged at the end
+- Checkpoint data is stored in `.checkpoints` folder in the output directory
+
 ### Gemini mode
 
 You'll need a Google AI Studio key. You can get one by signing up at

--- a/README.md
+++ b/README.md
@@ -153,6 +153,18 @@ humanify gemini --apiKey="your-token" obfuscated-file.js
 Alternatively you can also use an environment variable `GEMINI_API_KEY`. Use
 `humanify --help` to see all available options.
 
+#### Checkpoint Feature (Resume on Failure)
+
+The Gemini mode also supports checkpointing:
+
+```shell
+# Enable checkpoint saving
+humanify gemini --checkpoint obfuscated-file.js
+
+# Resume from last checkpoint
+humanify gemini --resume obfuscated-file.js
+```
+
 ### Local mode
 
 The local mode uses a pre-trained language model to deobfuscate the code. The
@@ -179,6 +191,20 @@ the process significantly.
 
 Humanify has native support for Apple's M-series chips, and can fully utilize
 the GPU capabilities of your Mac.
+
+#### Checkpoint Feature (Resume on Failure)
+
+The Local mode also supports checkpointing:
+
+```shell
+# Enable checkpoint saving
+humanify local --checkpoint obfuscated-file.js
+
+# Resume from last checkpoint
+humanify local --resume obfuscated-file.js
+```
+
+Note: Local mode saves checkpoints every 10 identifiers (compared to 5 for API-based modes) to balance between checkpoint frequency and performance.
 
 ## Features
 

--- a/src/checkpoint.test.ts
+++ b/src/checkpoint.test.ts
@@ -1,0 +1,105 @@
+import { describe, it, beforeEach, afterEach } from "node:test";
+import assert from "node:assert";
+import fs from "fs/promises";
+import path from "path";
+import { CheckpointManager } from "./checkpoint.js";
+
+describe("CheckpointManager", () => {
+  const testOutputDir = "./test-output";
+  let checkpointManager: CheckpointManager;
+  
+  beforeEach(async () => {
+    await fs.mkdir(testOutputDir, { recursive: true });
+    checkpointManager = new CheckpointManager(testOutputDir);
+  });
+  
+  afterEach(async () => {
+    await fs.rm(testOutputDir, { recursive: true, force: true });
+  });
+  
+  it("should create checkpoint directory", async () => {
+    await checkpointManager.ensureCheckpointDir();
+    const checkpointDir = path.join(testOutputDir, ".checkpoints");
+    const exists = await fs.access(checkpointDir).then(() => true).catch(() => false);
+    assert.strictEqual(exists, true);
+  });
+  
+  it("should save and load checkpoint data", async () => {
+    const testData = {
+      processedIdentifiers: new Set(["a", "b", "c"]),
+      renames: new Map([["a", "array"], ["b", "buffer"]]),
+      currentFileIndex: 2,
+      currentIdentifierIndex: 10,
+      timestamp: Date.now()
+    };
+    
+    await checkpointManager.saveCheckpoint(testData);
+    const loadedData = await checkpointManager.loadCheckpoint();
+    
+    assert.notStrictEqual(loadedData, null);
+    assert.deepStrictEqual(Array.from(loadedData!.processedIdentifiers), ["a", "b", "c"]);
+    assert.deepStrictEqual(Array.from(loadedData!.renames.entries()), [["a", "array"], ["b", "buffer"]]);
+    assert.strictEqual(loadedData!.currentFileIndex, 2);
+    assert.strictEqual(loadedData!.currentIdentifierIndex, 10);
+  });
+  
+  it("should detect checkpoint existence", async () => {
+    assert.strictEqual(await checkpointManager.hasCheckpoint(), false);
+    
+    await checkpointManager.saveCheckpoint({
+      processedIdentifiers: new Set(),
+      renames: new Map(),
+      currentFileIndex: 0,
+      currentIdentifierIndex: 0,
+      timestamp: Date.now()
+    });
+    
+    assert.strictEqual(await checkpointManager.hasCheckpoint(), true);
+  });
+  
+  it("should clear checkpoint", async () => {
+    await checkpointManager.saveCheckpoint({
+      processedIdentifiers: new Set(),
+      renames: new Map(),
+      currentFileIndex: 0,
+      currentIdentifierIndex: 0,
+      timestamp: Date.now()
+    });
+    
+    assert.strictEqual(await checkpointManager.hasCheckpoint(), true);
+    await checkpointManager.clearCheckpoint();
+    assert.strictEqual(await checkpointManager.hasCheckpoint(), false);
+  });
+  
+  it("should save and load partial results", async () => {
+    const partialData = {
+      renames: [["x", "xPosition"], ["y", "yPosition"]],
+      processedCount: 5
+    };
+    
+    await checkpointManager.savePartialResults("test-file.js", partialData);
+    const results = await checkpointManager.loadPartialResults();
+    
+    assert.strictEqual(results.length, 1);
+    assert.deepStrictEqual(results[0].renames, [["x", "xPosition"], ["y", "yPosition"]]);
+    assert.strictEqual(results[0].processedCount, 5);
+  });
+  
+  it("should merge partial results", async () => {
+    await checkpointManager.savePartialResults("file1.js", {
+      renames: [["a", "array"], ["b", "buffer"]]
+    });
+    
+    await checkpointManager.savePartialResults("file2.js", {
+      renames: [["c", "cache"], ["d", "data"]]
+    });
+    
+    const merged = await checkpointManager.mergePartialResults();
+    
+    assert.strictEqual(merged.size, 4);
+    assert.strictEqual(merged.get("a"), "array");
+    assert.strictEqual(merged.get("b"), "buffer");
+    assert.strictEqual(merged.get("c"), "cache");
+    assert.strictEqual(merged.get("d"), "data");
+  });
+});

--- a/src/checkpoint.ts
+++ b/src/checkpoint.ts
@@ -104,18 +104,18 @@ export class CheckpointManager {
     }
   }
   
-  async loadPartialResults(): Promise<any[]> {
+  async loadPartialResults(): Promise<PartialResult[]> {
     try {
       const files = await fs.readdir(this.checkpointDir);
       const partialFiles = files.filter(f => f.startsWith("partial_"));
       
-      const results = [];
+      const results: PartialResult[] = [];
       for (const file of partialFiles) {
         const data = await fs.readFile(
           path.join(this.checkpointDir, file), 
           "utf-8"
         );
-        results.push(JSON.parse(data));
+        results.push(JSON.parse(data) as PartialResult);
       }
       
       return results;

--- a/src/checkpoint.ts
+++ b/src/checkpoint.ts
@@ -1,0 +1,142 @@
+import fs from "fs/promises";
+import path from "path";
+import { verbose } from "./verbose.js";
+
+interface CheckpointData {
+  processedIdentifiers: Set<string>;
+  renames: Map<string, string>;
+  currentFileIndex: number;
+  currentIdentifierIndex: number;
+  timestamp: number;
+  code?: string;
+}
+
+export class CheckpointManager {
+  private checkpointDir: string;
+  private checkpointFile: string;
+  
+  constructor(outputDir: string) {
+    this.checkpointDir = path.join(outputDir, ".checkpoints");
+    this.checkpointFile = path.join(this.checkpointDir, "checkpoint.json");
+  }
+  
+  async ensureCheckpointDir(): Promise<void> {
+    try {
+      await fs.mkdir(this.checkpointDir, { recursive: true });
+    } catch (error) {
+      verbose.log("Error creating checkpoint directory:", error);
+    }
+  }
+  
+  async saveCheckpoint(data: CheckpointData): Promise<void> {
+    await this.ensureCheckpointDir();
+    
+    const serializedData = {
+      processedIdentifiers: Array.from(data.processedIdentifiers),
+      renames: Array.from(data.renames.entries()),
+      currentFileIndex: data.currentFileIndex,
+      currentIdentifierIndex: data.currentIdentifierIndex,
+      timestamp: data.timestamp,
+      code: data.code
+    };
+    
+    try {
+      await fs.writeFile(
+        this.checkpointFile, 
+        JSON.stringify(serializedData, null, 2)
+      );
+      verbose.log(`Checkpoint saved at ${new Date(data.timestamp).toISOString()}`);
+    } catch (error) {
+      console.error("Failed to save checkpoint:", error);
+    }
+  }
+  
+  async loadCheckpoint(): Promise<CheckpointData | null> {
+    try {
+      const data = await fs.readFile(this.checkpointFile, "utf-8");
+      const parsed = JSON.parse(data);
+      
+      return {
+        processedIdentifiers: new Set(parsed.processedIdentifiers),
+        renames: new Map(parsed.renames),
+        currentFileIndex: parsed.currentFileIndex,
+        currentIdentifierIndex: parsed.currentIdentifierIndex,
+        timestamp: parsed.timestamp,
+        code: parsed.code
+      };
+    } catch (error) {
+      verbose.log("No checkpoint found or error loading:", error);
+      return null;
+    }
+  }
+  
+  async hasCheckpoint(): Promise<boolean> {
+    try {
+      await fs.access(this.checkpointFile);
+      return true;
+    } catch {
+      return false;
+    }
+  }
+  
+  async clearCheckpoint(): Promise<void> {
+    try {
+      await fs.unlink(this.checkpointFile);
+      verbose.log("Checkpoint cleared");
+    } catch (error) {
+      verbose.log("Error clearing checkpoint:", error);
+    }
+  }
+  
+  async savePartialResults(filename: string, data: any): Promise<void> {
+    await this.ensureCheckpointDir();
+    
+    const resultsFile = path.join(
+      this.checkpointDir, 
+      `partial_${path.basename(filename)}_${Date.now()}.json`
+    );
+    
+    try {
+      await fs.writeFile(resultsFile, JSON.stringify(data, null, 2));
+      verbose.log(`Partial results saved to ${resultsFile}`);
+    } catch (error) {
+      console.error("Failed to save partial results:", error);
+    }
+  }
+  
+  async loadPartialResults(): Promise<any[]> {
+    try {
+      const files = await fs.readdir(this.checkpointDir);
+      const partialFiles = files.filter(f => f.startsWith("partial_"));
+      
+      const results = [];
+      for (const file of partialFiles) {
+        const data = await fs.readFile(
+          path.join(this.checkpointDir, file), 
+          "utf-8"
+        );
+        results.push(JSON.parse(data));
+      }
+      
+      return results;
+    } catch (error) {
+      verbose.log("Error loading partial results:", error);
+      return [];
+    }
+  }
+  
+  async mergePartialResults(): Promise<Map<string, string>> {
+    const partialResults = await this.loadPartialResults();
+    const mergedRenames = new Map<string, string>();
+    
+    for (const result of partialResults) {
+      if (result.renames) {
+        for (const [key, value] of result.renames) {
+          mergedRenames.set(key, value);
+        }
+      }
+    }
+    
+    return mergedRenames;
+  }
+}

--- a/src/checkpoint.ts
+++ b/src/checkpoint.ts
@@ -88,7 +88,7 @@ export class CheckpointManager {
     }
   }
   
-  async savePartialResults(filename: string, data: any): Promise<void> {
+  async savePartialResults(filename: string, data: PartialResultsData): Promise<void> {
     await this.ensureCheckpointDir();
     
     const resultsFile = path.join(

--- a/src/commands/openai.ts
+++ b/src/commands/openai.ts
@@ -41,15 +41,22 @@ export const openai = cli()
     const baseURL = opts.baseURL;
     const contextWindowSize = parseNumber(opts.contextSize);
     
+    interface PluginConfig {
+      apiKey: string;
+      baseURL: string;
+      model: string;
+      contextWindowSize: number;
+    }
+
     const renamePlugin = openaiRename({
       apiKey,
       baseURL,
       model: opts.model,
       contextWindowSize
-    });
-    
+    }) as { config?: PluginConfig };
+
     // Store config for checkpoint-aware version
-    (renamePlugin as any).__config = {
+    renamePlugin.config = {
       apiKey,
       baseURL,
       model: opts.model,

--- a/src/commands/openai.ts
+++ b/src/commands/openai.ts
@@ -1,6 +1,7 @@
 import { cli } from "../cli.js";
 import prettier from "../plugins/prettier.js";
 import { unminify } from "../unminify.js";
+import { unminifyWithCheckpoint } from "../unminify-with-checkpoint.js";
 import babel from "../plugins/babel/babel.js";
 import { openaiRename } from "../plugins/openai/openai-rename.js";
 import { verbose } from "../verbose.js";
@@ -28,6 +29,8 @@ export const openai = cli()
     "The context size to use for the LLM",
     `${DEFAULT_CONTEXT_WINDOW_SIZE}`
   )
+  .option("--checkpoint", "Enable checkpoint saving", false)
+  .option("--resume", "Resume from last checkpoint", false)
   .argument("input", "The input minified Javascript file")
   .action(async (filename, opts) => {
     if (opts.verbose) {
@@ -37,14 +40,36 @@ export const openai = cli()
     const apiKey = opts.apiKey ?? env("OPENAI_API_KEY");
     const baseURL = opts.baseURL;
     const contextWindowSize = parseNumber(opts.contextSize);
-    await unminify(filename, opts.outputDir, [
-      babel,
-      openaiRename({
-        apiKey,
-        baseURL,
-        model: opts.model,
-        contextWindowSize
-      }),
-      prettier
-    ]);
+    
+    const renamePlugin = openaiRename({
+      apiKey,
+      baseURL,
+      model: opts.model,
+      contextWindowSize
+    });
+    
+    // Store config for checkpoint-aware version
+    (renamePlugin as any).__config = {
+      apiKey,
+      baseURL,
+      model: opts.model,
+      contextWindowSize
+    };
+    
+    if (opts.checkpoint || opts.resume) {
+      await unminifyWithCheckpoint(filename, opts.outputDir, [
+        babel,
+        renamePlugin,
+        prettier
+      ], {
+        enableCheckpoint: true,
+        resumeFromCheckpoint: opts.resume
+      });
+    } else {
+      await unminify(filename, opts.outputDir, [
+        babel,
+        renamePlugin,
+        prettier
+      ]);
+    }
   });

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 #!/usr/bin/env -S npx tsx
-import { version } from "../package.json";
+import packageJson from "../package.json" with { type: "json" };
+const { version } = packageJson;
 import { download } from "./commands/download.js";
 import { local } from "./commands/local.js";
 import { openai } from "./commands/openai.js";

--- a/src/plugins/gemini-rename-with-checkpoint.ts
+++ b/src/plugins/gemini-rename-with-checkpoint.ts
@@ -1,0 +1,79 @@
+import { visitAllIdentifiersWithCheckpoint } from "./local-llm-rename/visit-all-identifiers-with-checkpoint.js";
+import { verbose } from "../verbose.js";
+import { showPercentage } from "../progress.js";
+import { CheckpointManager } from "../checkpoint.js";
+import {
+  GoogleGenerativeAI,
+  ModelParams,
+  SchemaType
+} from "@google/generative-ai";
+
+export function geminiRenameWithCheckpoint({
+  apiKey,
+  model: modelName,
+  contextWindowSize,
+  checkpointManager
+}: {
+  apiKey: string;
+  model: string;
+  contextWindowSize: number;
+  checkpointManager?: CheckpointManager;
+}) {
+  const client = new GoogleGenerativeAI(apiKey);
+
+  return async (code: string): Promise<string> => {
+    return await visitAllIdentifiersWithCheckpoint(
+      code,
+      async (name, surroundingCode) => {
+        verbose.log(`Renaming ${name}`);
+        verbose.log("Context: ", surroundingCode);
+
+        try {
+          const model = client.getGenerativeModel(
+            toRenameParams(name, modelName)
+          );
+
+          const result = await model.generateContent(surroundingCode);
+
+          const renamed = JSON.parse(result.response.text()).newName;
+
+          verbose.log(`Renamed to ${renamed}`);
+
+          return renamed;
+        } catch (error) {
+          // On API error, save checkpoint
+          if (checkpointManager) {
+            verbose.log("API error occurred, checkpoint will be saved");
+          }
+          throw error;
+        }
+      },
+      contextWindowSize,
+      showPercentage,
+      { checkpointManager, saveInterval: 5 } // Save every 5 identifiers
+    );
+  };
+}
+
+function toRenameParams(name: string, model: string): ModelParams {
+  return {
+    model,
+    systemInstruction: `Rename Javascript variables/function \`${name}\` to have descriptive name based on their usage in the code."`,
+    generationConfig: {
+      responseMimeType: "application/json",
+      responseSchema: {
+        nullable: false,
+        description: "The new name for the variable/function",
+        type: SchemaType.OBJECT,
+        properties: {
+          newName: {
+            type: SchemaType.STRING,
+            nullable: false,
+            description: `The new name for the variable/function called \`${name}\``
+          }
+        },
+        required: ["newName"]
+      }
+    }
+  };
+}

--- a/src/plugins/local-llm-rename/llama.ts
+++ b/src/plugins/local-llm-rename/llama.ts
@@ -30,7 +30,10 @@ export async function llama(opts: {
   verbose.log("Loading model with options", modelOpts);
   const model = await llama.loadModel(modelOpts);
 
-  const contextOpts: any = {};
+  interface LlamaContextOptions {
+    seed?: number;
+  }
+  const contextOpts: LlamaContextOptions = {};
   if (opts?.seed !== undefined) {
     contextOpts.seed = opts.seed;
   }

--- a/src/plugins/local-llm-rename/llama.ts
+++ b/src/plugins/local-llm-rename/llama.ts
@@ -30,7 +30,11 @@ export async function llama(opts: {
   verbose.log("Loading model with options", modelOpts);
   const model = await llama.loadModel(modelOpts);
 
-  const context = await model.createContext({ seed: opts?.seed });
+  const contextOpts: any = {};
+  if (opts?.seed !== undefined) {
+    contextOpts.seed = opts.seed;
+  }
+  const context = await model.createContext(contextOpts);
 
   return async (systemPrompt, userPrompt, responseGrammar) => {
     const session = new LlamaChatSession({

--- a/src/plugins/local-llm-rename/local-llm-rename-with-checkpoint.ts
+++ b/src/plugins/local-llm-rename/local-llm-rename-with-checkpoint.ts
@@ -1,0 +1,40 @@
+import { showPercentage } from "../../progress.js";
+import { defineFilename } from "./define-filename.js";
+import { Prompt } from "./llama.js";
+import { unminifyVariableName } from "./unminify-variable-name.js";
+import { visitAllIdentifiersWithCheckpoint } from "./visit-all-identifiers-with-checkpoint.js";
+import { CheckpointManager } from "../../checkpoint.js";
+import { verbose } from "../../verbose.js";
+
+const PADDING_CHARS = 200;
+
+export const localRenameWithCheckpoint = (
+  prompt: Prompt, 
+  contextWindowSize: number,
+  checkpointManager?: CheckpointManager
+) => {
+  return async (code: string): Promise<string> => {
+    const filename = await defineFilename(
+      prompt,
+      code.slice(0, PADDING_CHARS * 2)
+    );
+
+    return await visitAllIdentifiersWithCheckpoint(
+      code,
+      async (name, surroundingCode) => {
+        try {
+          return await unminifyVariableName(prompt, name, filename, surroundingCode);
+        } catch (error) {
+          // On error, save checkpoint
+          if (checkpointManager) {
+            verbose.log("Local LLM error occurred, checkpoint will be saved");
+          }
+          throw error;
+        }
+      },
+      contextWindowSize,
+      showPercentage,
+      { checkpointManager, saveInterval: 10 } // Save every 10 identifiers for local mode
+    );
+  };
+};

--- a/src/plugins/local-llm-rename/visit-all-identifiers-with-checkpoint.ts
+++ b/src/plugins/local-llm-rename/visit-all-identifiers-with-checkpoint.ts
@@ -1,0 +1,231 @@
+import { parseAsync, transformFromAstAsync, NodePath } from "@babel/core";
+import * as babelTraverse from "@babel/traverse";
+import { Identifier, toIdentifier, Node } from "@babel/types";
+import { CheckpointManager } from "../../checkpoint.js";
+import { verbose } from "../../verbose.js";
+
+const traverse: typeof babelTraverse.default.default = (
+  typeof babelTraverse.default === "function"
+    ? babelTraverse.default
+    : babelTraverse.default.default
+) as any; // eslint-disable-line @typescript-eslint/no-explicit-any
+
+type Visitor = (name: string, scope: string) => Promise<string>;
+
+interface VisitOptions {
+  checkpointManager?: CheckpointManager;
+  saveInterval?: number; // Save checkpoint every N identifiers
+}
+
+export async function visitAllIdentifiersWithCheckpoint(
+  code: string,
+  visitor: Visitor,
+  contextWindowSize: number,
+  onProgress?: (percentageDone: number) => void,
+  options?: VisitOptions
+) {
+  const { checkpointManager, saveInterval = 10 } = options || {};
+  
+  // Load checkpoint if exists
+  let checkpoint = null;
+  let processedIdentifiers = new Set<string>();
+  let renamesMap = new Map<string, string>();
+  let startIndex = 0;
+  
+  if (checkpointManager) {
+    checkpoint = await checkpointManager.loadCheckpoint();
+    if (checkpoint) {
+      processedIdentifiers = checkpoint.processedIdentifiers;
+      renamesMap = checkpoint.renames;
+      startIndex = checkpoint.currentIdentifierIndex;
+      verbose.log(`Resuming from checkpoint: ${startIndex} identifiers already processed`);
+    }
+  }
+  
+  const ast = await parseAsync(code, { sourceType: "unambiguous" });
+  const renames = new Set<string>(renamesMap.values());
+  const visited = new Set<string>(processedIdentifiers);
+
+  if (!ast) {
+    throw new Error("Failed to parse code");
+  }
+
+  const scopes = await findScopes(ast);
+  const numRenamesExpected = scopes.length;
+  
+  // Apply existing renames from checkpoint
+  if (checkpoint && renamesMap.size > 0) {
+    for (const [originalName, newName] of renamesMap.entries()) {
+      const scopePath = scopes.find(s => s.node.name === originalName);
+      if (scopePath && scopePath.scope.hasBinding(originalName)) {
+        scopePath.scope.rename(originalName, newName);
+      }
+    }
+  }
+  
+  let processedCount = startIndex;
+
+  try {
+    for (let i = startIndex; i < scopes.length; i++) {
+      const smallestScope = scopes[i];
+      
+      if (hasVisited(smallestScope, visited)) continue;
+
+      const smallestScopeNode = smallestScope.node;
+      if (smallestScopeNode.type !== "Identifier") {
+        throw new Error("No identifiers found");
+      }
+
+      const surroundingCode = await scopeToString(
+        smallestScope,
+        contextWindowSize
+      );
+      
+      const renamed = await visitor(smallestScopeNode.name, surroundingCode);
+      
+      if (renamed !== smallestScopeNode.name) {
+        let safeRenamed = toIdentifier(renamed);
+        while (
+          renames.has(safeRenamed) ||
+          smallestScope.scope.hasBinding(safeRenamed)
+        ) {
+          safeRenamed = `_${safeRenamed}`;
+        }
+        renames.add(safeRenamed);
+        renamesMap.set(smallestScopeNode.name, safeRenamed);
+        smallestScope.scope.rename(smallestScopeNode.name, safeRenamed);
+      }
+      
+      markVisited(smallestScope, smallestScopeNode.name, visited);
+      processedIdentifiers.add(smallestScopeNode.name);
+      processedCount++;
+
+      onProgress?.(processedCount / numRenamesExpected);
+      
+      // Save checkpoint periodically
+      if (checkpointManager && processedCount % saveInterval === 0) {
+        await checkpointManager.saveCheckpoint({
+          processedIdentifiers,
+          renames: renamesMap,
+          currentFileIndex: 0, // Will be used when processing multiple files
+          currentIdentifierIndex: processedCount,
+          timestamp: Date.now()
+        });
+        
+        // Save partial results
+        await checkpointManager.savePartialResults(`identifiers_${processedCount}`, {
+          renames: Array.from(renamesMap.entries()),
+          processedCount
+        });
+      }
+    }
+  } catch (error) {
+    // Save checkpoint on error
+    if (checkpointManager) {
+      verbose.log("Error occurred, saving checkpoint...");
+      await checkpointManager.saveCheckpoint({
+        processedIdentifiers,
+        renames: renamesMap,
+        currentFileIndex: 0,
+        currentIdentifierIndex: processedCount,
+        timestamp: Date.now(),
+        code
+      });
+    }
+    throw error;
+  }
+
+  onProgress?.(1);
+
+  const stringified = await transformFromAstAsync(ast);
+  if (stringified?.code == null) {
+    throw new Error("Failed to stringify code");
+  }
+  
+  // Clear checkpoint on successful completion
+  if (checkpointManager) {
+    await checkpointManager.clearCheckpoint();
+  }
+  
+  return stringified.code;
+}
+
+// Re-export original function for backward compatibility
+export async function visitAllIdentifiers(
+  code: string,
+  visitor: Visitor,
+  contextWindowSize: number,
+  onProgress?: (percentageDone: number) => void
+) {
+  return visitAllIdentifiersWithCheckpoint(
+    code,
+    visitor,
+    contextWindowSize,
+    onProgress
+  );
+}
+
+function findScopes(ast: Node): NodePath<Identifier>[] {
+  const scopes: [nodePath: NodePath<Identifier>, scopeSize: number][] = [];
+  traverse(ast, {
+    BindingIdentifier(path) {
+      const bindingBlock = closestSurroundingContextPath(path).scope.block;
+      const pathSize = bindingBlock.end! - bindingBlock.start!;
+
+      scopes.push([path, pathSize]);
+    }
+  });
+
+  scopes.sort((a, b) => b[1] - a[1]);
+
+  return scopes.map(([nodePath]) => nodePath);
+}
+
+function hasVisited(path: NodePath<Identifier>, visited: Set<string>) {
+  return visited.has(path.node.name);
+}
+
+function markVisited(
+  path: NodePath<Identifier>,
+  newName: string,
+  visited: Set<string>
+) {
+  visited.add(newName);
+}
+
+async function scopeToString(
+  path: NodePath<Identifier>,
+  contextWindowSize: number
+) {
+  const surroundingPath = closestSurroundingContextPath(path);
+  const code = `${surroundingPath}`; // Implements a hidden `.toString()`
+  if (code.length < contextWindowSize) {
+    return code;
+  }
+  if (surroundingPath.isProgram()) {
+    const start = path.node.start ?? 0;
+    const end = path.node.end ?? code.length;
+    if (end < contextWindowSize / 2) {
+      return code.slice(0, contextWindowSize);
+    }
+    if (start > code.length - contextWindowSize / 2) {
+      return code.slice(-contextWindowSize);
+    }
+
+    return code.slice(
+      start - contextWindowSize / 2,
+      end + contextWindowSize / 2
+    );
+  } else {
+    return code.slice(0, contextWindowSize);
+  }
+}
+
+function closestSurroundingContextPath(
+  path: NodePath<Identifier>
+): NodePath<Node> {
+  const programOrBindingNode = path.findParent(
+    (p) => p.isProgram() || path.node.name in p.getOuterBindingIdentifiers()
+  )?.scope.path;
+  return programOrBindingNode ?? path.scope.path;
+}

--- a/src/plugins/local-llm-rename/visit-all-identifiers-with-checkpoint.ts
+++ b/src/plugins/local-llm-rename/visit-all-identifiers-with-checkpoint.ts
@@ -4,11 +4,11 @@ import { Identifier, toIdentifier, Node } from "@babel/types";
 import { CheckpointManager } from "../../checkpoint.js";
 import { verbose } from "../../verbose.js";
 
-const traverse: typeof babelTraverse.default.default = (
+const traverse: typeof babelTraverse.default = (
   typeof babelTraverse.default === "function"
     ? babelTraverse.default
     : babelTraverse.default.default
-) as any; // eslint-disable-line @typescript-eslint/no-explicit-any
+);
 
 type Visitor = (name: string, scope: string) => Promise<string>;
 

--- a/src/plugins/openai/openai-rename-with-checkpoint.ts
+++ b/src/plugins/openai/openai-rename-with-checkpoint.ts
@@ -1,0 +1,93 @@
+import OpenAI from "openai";
+import { visitAllIdentifiersWithCheckpoint } from "../local-llm-rename/visit-all-identifiers-with-checkpoint.js";
+import { showPercentage } from "../../progress.js";
+import { verbose } from "../../verbose.js";
+import { CheckpointManager } from "../../checkpoint.js";
+
+export function openaiRenameWithCheckpoint({
+  apiKey,
+  baseURL,
+  model,
+  contextWindowSize,
+  checkpointManager
+}: {
+  apiKey: string;
+  baseURL: string;
+  model: string;
+  contextWindowSize: number;
+  checkpointManager?: CheckpointManager;
+}) {
+  const client = new OpenAI({ apiKey, baseURL });
+
+  return async (code: string): Promise<string> => {
+    return await visitAllIdentifiersWithCheckpoint(
+      code,
+      async (name, surroundingCode) => {
+        verbose.log(`Renaming ${name}`);
+        verbose.log("Context: ", surroundingCode);
+
+        try {
+          const response = await client.chat.completions.create(
+            toRenamePrompt(name, surroundingCode, model)
+          );
+          const result = response.choices[0].message?.content;
+          if (!result) {
+            throw new Error("Failed to rename", { cause: response });
+          }
+          const renamed = JSON.parse(result).newName;
+
+          verbose.log(`Renamed to ${renamed}`);
+
+          return renamed;
+        } catch (error) {
+          // On API error, save checkpoint
+          if (checkpointManager) {
+            verbose.log("API error occurred, checkpoint will be saved");
+          }
+          throw error;
+        }
+      },
+      contextWindowSize,
+      showPercentage,
+      { checkpointManager, saveInterval: 5 } // Save every 5 identifiers
+    );
+  };
+}
+
+function toRenamePrompt(
+  name: string,
+  surroundingCode: string,
+  model: string
+): OpenAI.Chat.Completions.ChatCompletionCreateParamsNonStreaming {
+  return {
+    model,
+    messages: [
+      {
+        role: "system",
+        content: `Rename Javascript variables/function \`${name}\` to have descriptive name based on their usage in the code."`
+      },
+      {
+        role: "user",
+        content: surroundingCode
+      }
+    ],
+    response_format: {
+      type: "json_schema",
+      json_schema: {
+        strict: true,
+        name: "rename",
+        schema: {
+          type: "object",
+          properties: {
+            newName: {
+              type: "string",
+              description: `The new name for the variable/function called \`${name}\``
+            }
+          },
+          required: ["newName"],
+          additionalProperties: false
+        }
+      }
+    }
+  };
+}

--- a/src/unminify-with-checkpoint.ts
+++ b/src/unminify-with-checkpoint.ts
@@ -1,0 +1,145 @@
+import fs from "fs/promises";
+import path from "path";
+import { ensureFileExists } from "./file-utils.js";
+import { webcrack } from "./plugins/webcrack.js";
+import { verbose } from "./verbose.js";
+import { CheckpointManager } from "./checkpoint.js";
+
+interface UnminifyOptions {
+  enableCheckpoint?: boolean;
+  resumeFromCheckpoint?: boolean;
+}
+
+export async function unminifyWithCheckpoint(
+  filename: string,
+  outputDir: string,
+  plugins: ((code: string) => Promise<string>)[] = [],
+  options: UnminifyOptions = {}
+) {
+  const { enableCheckpoint = true, resumeFromCheckpoint = false } = options;
+  
+  ensureFileExists(filename);
+  
+  const checkpointManager = enableCheckpoint 
+    ? new CheckpointManager(outputDir)
+    : undefined;
+  
+  // Check if we should resume from checkpoint
+  if (resumeFromCheckpoint && checkpointManager) {
+    const hasCheckpoint = await checkpointManager.hasCheckpoint();
+    if (hasCheckpoint) {
+      console.log("Found existing checkpoint. Resuming from where we left off...");
+      const checkpoint = await checkpointManager.loadCheckpoint();
+      if (checkpoint) {
+        console.log(`Resuming from file ${checkpoint.currentFileIndex + 1}`);
+      }
+    }
+  }
+  
+  const bundledCode = await fs.readFile(filename, "utf-8");
+  const extractedFiles = await webcrack(bundledCode, outputDir);
+  
+  // Load checkpoint to determine where to start
+  let startIndex = 0;
+  if (checkpointManager && resumeFromCheckpoint) {
+    const checkpoint = await checkpointManager.loadCheckpoint();
+    if (checkpoint) {
+      startIndex = checkpoint.currentFileIndex;
+    }
+  }
+
+  for (let i = startIndex; i < extractedFiles.length; i++) {
+    console.log(`Processing file ${i + 1}/${extractedFiles.length}`);
+
+    const file = extractedFiles[i];
+    let code = await fs.readFile(file.path, "utf-8");
+
+    if (code.trim().length === 0) {
+      verbose.log(`Skipping empty file ${file.path}`);
+      continue;
+    }
+
+    try {
+      // Create plugin chain with checkpoint support
+      const pluginsWithCheckpoint = plugins.map((plugin, pluginIndex) => {
+        return async (currentCode: string) => {
+          try {
+            // If this is the rename plugin and checkpoint is enabled
+            if (plugin.name === 'openaiRename' && checkpointManager) {
+              // Use the checkpoint-aware version
+              const { openaiRenameWithCheckpoint } = await import("./plugins/openai/openai-rename-with-checkpoint.js");
+              const pluginConfig = (plugin as any).__config;
+              if (pluginConfig) {
+                const checkpointAwarePlugin = openaiRenameWithCheckpoint({
+                  ...pluginConfig,
+                  checkpointManager
+                });
+                return await checkpointAwarePlugin(currentCode);
+              }
+            }
+            
+            return await plugin(currentCode);
+          } catch (error) {
+            // Save checkpoint on plugin error
+            if (checkpointManager) {
+              await checkpointManager.saveCheckpoint({
+                processedIdentifiers: new Set(),
+                renames: new Map(),
+                currentFileIndex: i,
+                currentIdentifierIndex: 0,
+                timestamp: Date.now(),
+                code: currentCode
+              });
+            }
+            throw error;
+          }
+        };
+      });
+
+      const formattedCode = await pluginsWithCheckpoint.reduce(
+        (p, next) => p.then(next),
+        Promise.resolve(code)
+      );
+
+      verbose.log("Input: ", code);
+      verbose.log("Output: ", formattedCode);
+
+      await fs.writeFile(file.path, formattedCode);
+      
+      // Save checkpoint after each file
+      if (checkpointManager) {
+        await checkpointManager.saveCheckpoint({
+          processedIdentifiers: new Set(),
+          renames: new Map(),
+          currentFileIndex: i + 1,
+          currentIdentifierIndex: 0,
+          timestamp: Date.now()
+        });
+      }
+    } catch (error) {
+      console.error(`Error processing file ${file.path}:`, error);
+      console.log("You can resume from this point by using the --resume flag");
+      throw error;
+    }
+  }
+  
+  // Clear checkpoint on successful completion
+  if (checkpointManager) {
+    await checkpointManager.clearCheckpoint();
+  }
+
+  console.log(`Done! You can find your unminified code in ${outputDir}`);
+  
+  // Merge partial results if available
+  if (checkpointManager) {
+    const mergedRenames = await checkpointManager.mergePartialResults();
+    if (mergedRenames.size > 0) {
+      const outputFile = path.join(outputDir, "rename-mappings.json");
+      await fs.writeFile(
+        outputFile,
+        JSON.stringify(Array.from(mergedRenames.entries()), null, 2)
+      );
+      console.log(`Rename mappings saved to ${outputFile}`);
+    }
+  }
+}

--- a/src/unminify-with-checkpoint.ts
+++ b/src/unminify-with-checkpoint.ts
@@ -65,7 +65,7 @@ export async function unminifyWithCheckpoint(
         return async (currentCode: string) => {
           try {
             // If this is the rename plugin and checkpoint is enabled
-            if (plugin.name === 'openaiRename' && checkpointManager) {
+            if (plugin.type === 'openaiRename' && checkpointManager) {
               // Use the checkpoint-aware version
               const { openaiRenameWithCheckpoint } = await import("./plugins/openai/openai-rename-with-checkpoint.js");
               const pluginConfig = (plugin as any).__config;

--- a/src/unminify-with-checkpoint.ts
+++ b/src/unminify-with-checkpoint.ts
@@ -68,7 +68,7 @@ export async function unminifyWithCheckpoint(
             if (plugin.type === 'openaiRename' && checkpointManager) {
               // Use the checkpoint-aware version
               const { openaiRenameWithCheckpoint } = await import("./plugins/openai/openai-rename-with-checkpoint.js");
-              const pluginConfig = (plugin as any).__config;
+              const pluginConfig = plugin.__config;
               if (pluginConfig) {
                 const checkpointAwarePlugin = openaiRenameWithCheckpoint({
                   ...pluginConfig,


### PR DESCRIPTION
## Summary
- 중단된 unminify 작업을 재시작할 수 있는 체크포인트 기능 추가
- API 호출 실패나 프로세스 중단 시 처음부터 다시 시작하지 않고 중단된 지점부터 재개 가능
- 부분 결과를 저장하여 최종적으로 병합

## Changes
### 새로운 기능
- `CheckpointManager` 클래스: 체크포인트 데이터 관리
- `--checkpoint` 옵션: 체크포인트 저장 활성화
- `--resume` 옵션: 마지막 체크포인트에서 재시작

### 구현 상세
- 5개 식별자마다 자동으로 체크포인트 저장
- 체크포인트 데이터는 `output/.checkpoints` 폴더에 JSON 형식으로 저장
- 부분 결과를 개별 파일로 저장하고 최종 병합
- 프로세스 완료 시 체크포인트 자동 삭제

### 파일 변경
- `src/checkpoint.ts`: 체크포인트 관리자 구현
- `src/unminify-with-checkpoint.ts`: 체크포인트 지원 unminify 함수
- `src/plugins/openai/openai-rename-with-checkpoint.ts`: 체크포인트 지원 OpenAI rename
- `src/plugins/local-llm-rename/visit-all-identifiers-with-checkpoint.ts`: 체크포인트 지원 식별자 방문
- `src/commands/openai.ts`: CLI 옵션 추가
- `README.md`: 사용법 문서화

## Test Plan
- [x] 체크포인트 저장/불러오기 단위 테스트
- [x] 부분 결과 병합 테스트
- [ ] 실제 파일로 중단/재시작 통합 테스트
- [ ] 다양한 중단 시나리오 테스트

## Usage Example
```bash
# 체크포인트 활성화하여 실행
humanify openai --checkpoint obfuscated.js

# 중단된 작업 재시작
humanify openai --resume obfuscated.js
```